### PR TITLE
Fixed/added methods for breadcrumbs

### DIFF
--- a/src/app/code/community/N98/LayoutHelper/Block/Customer/Account/Navigation.php
+++ b/src/app/code/community/N98/LayoutHelper/Block/Customer/Account/Navigation.php
@@ -35,12 +35,14 @@ class N98_LayoutHelper_Block_Customer_Account_Navigation extends Mage_Customer_B
     /**
      * Remove a link
      *
-     * @param $name Name of the link
+     * @param string $name Name of the link
      * @return \N98_LayoutHelper_Block_Customer_Account_Navigation
      */
-    function removeLink($name)
+    public function removeLink($name)
     {
-        unset($this->_links[$name]);
+        if (isset($this->_links[$name])) {
+            unset($this->_links[$name]);
+        }
         return $this;
     }
 }

--- a/src/app/code/community/N98/LayoutHelper/Block/Page/Html/Breadcrumbs.php
+++ b/src/app/code/community/N98/LayoutHelper/Block/Page/Html/Breadcrumbs.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * netz98 magento module
+ *
+ * LICENSE
+ *
+ * This source file is subject of netz98.
+ * You may be not allowed to change the sources
+ * without authorization of netz98 new media GmbH.
+ *
+ * @copyright  Copyright (c) 2012 netz98 new media GmbH (http://www.netz98.de)
+ * @author netz98 new media GmbH <info@netz98.de>
+ * @category N98
+ * @package N98_LayoutHelper
+ */
+
+/**
+ * Provides additional function to be called in layout/local.xml
+ *
+ * @author netz98 new media GmbH <info@netz98.de>
+ * @category N98
+ * @package N98_LayoutHelper
+ */
+class N98_LayoutHelper_Block_Page_Html_Breadcrumbs extends Mage_Page_Block_Html_Breadcrumbs
+{
+
+    /**
+     * Set the original module name avoid breaking translations
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setModuleName('Mage_Page');
+    }
+
+    /**
+     * Add crumb after another
+     *
+     * @param string $crumbName Name of the crumb
+     * @param array $crumbInfo Crumb data
+     * @param string $before Insert after crumb name
+     */
+    public function addCrumb($crumbName, $crumbInfo, $after = false)
+    {
+        $this->_prepareArray($crumbInfo, array('label', 'title', 'link', 'first', 'last', 'readonly'));
+        if ((!isset($this->_crumbs[$crumbName])) || (!$this->_crumbs[$crumbName]['readonly'])) {
+            if ($after && isset($this->_crumbs[$after])) {
+                $offset = array_search($after, array_keys($this->_crumbs)) + 1;
+                $this->_crumbs = array_slice($this->_crumbs, 0, $offset, true) + array($crumbName => $crumbInfo) + array_slice($this->_crumbs, $offset, null, true);
+            } else {
+                $this->_crumbs[$crumbName] = $crumbInfo;
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Add crumb before another
+     *
+     * @param string $crumbName Name of the crumb
+     * @param array $crumbInfo Crumb data
+     * @param string $before Insert before crumb name
+     */
+    public function addCrumbBefore($crumbName, $crumbInfo, $before = false)
+    {
+        if ($before && isset($this->_crumbs[$before])) {
+            $keys = array_keys($this->_crumbs);
+            $offset = array_search($before, $keys);
+            # add before first
+            if (!$offset) {
+                $this->_prepareArray($crumbInfo, array('label', 'title', 'link', 'first', 'last', 'readonly'));
+                $this->_crumbs = array($crumbName => $crumbInfo) + $this->_crumbs;
+            } else {
+                $this->addCrumb($crumbName, $crumbInfo, $keys[$offset-1]);
+            }
+        } else {
+            $this->addCrumb($crumbName, $crumbInfo);
+        }
+    }
+
+    /**
+     * Remove a link
+     *
+     * @param string $name Name of the link
+     * @return \N98_LayoutHelper_Block_Page_Html_Breadcrumbs
+     */
+    public function removeCrumb($crumbName)
+    {
+        if (isset($this->_crumbs[$crumbName])) {
+            unset($this->_crumbs[$crumbName]);
+        }
+    }
+}

--- a/src/app/code/community/N98/LayoutHelper/Block/Sales/Order/Info.php
+++ b/src/app/code/community/N98/LayoutHelper/Block/Sales/Order/Info.php
@@ -34,11 +34,14 @@ class N98_LayoutHelper_Block_Sales_Order_Info extends Mage_Sales_Block_Order_Inf
     }
 
     /**
-     * Remove Link
+     * Remove a link
+     *
+     * @param string $name Name of the link
+     * @return \N98_LayoutHelper_Block_Sales_Order_Info
      */
     public function removeLink($name)
     {
-        if(isset($this->_links[$name])){
+        if (isset($this->_links[$name])) {
             unset($this->_links[$name]);
         }
         return $this;

--- a/src/app/code/community/N98/LayoutHelper/etc/config.xml
+++ b/src/app/code/community/N98/LayoutHelper/etc/config.xml
@@ -10,6 +10,7 @@
             <page>
                 <rewrite>
                     <html_head>N98_LayoutHelper_Block_Page_Html_Head</html_head>
+                    <html_breadcrumbs>N98_LayoutHelper_Block_Page_Html_Breadcrumbs</html_breadcrumbs>
                 </rewrite>
             </page>
             <customer>


### PR DESCRIPTION
- fixed bug where 3rd paramater `$after` has no use in `addCrumb`
- added method `addCrumbBefore`
- added method `removeCrumb`

Diff: https://github.com/OpenMage/magento-lts/pull/336/files